### PR TITLE
修复默认参数异常问题

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -12,8 +12,8 @@ var cos = {
     sid: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
     skey: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
     getAuthorization: function (method, pathname, callback) {
-        method = method.toUpperCase();
         method = method ? method : 'POST';
+        method = method.toUpperCase();
         pathname = pathname ? pathname : '/';
         pathname.substr(0, 1) != '/' && (pathname = '/' + pathname);
         var queryParams = {};


### PR DESCRIPTION
当method参数为undefined时会异常，调整两行代码顺序后正常。