### PR TITLE
修复Demo里的BUG

### DIFF
--- a/server/sts-auth.js
+++ b/server/sts-auth.js
@@ -143,7 +143,7 @@ var getTempKeys = function (callback) {
         Action: Action,
         durationSeconds: 7200,
         name: 'cos',
-        policy: encodeURIComponent(policyStr),
+        policy: encodeURIComponent(policyStr).replace(/\*/g,'%2A'),
     };
     params.Signature = util.getSignature(params, config.SecretKey, Method);
 
@@ -198,7 +198,7 @@ app.all('/sts-auth', function (req, res, next) {
                 SecretKey: tempKeys.credentials.tmpSecretKey,
                 Method: req.body.method || req.query.method,
                 Key: Key,
-                Query: req.body.query || req.query.method || {},
+                Query: req.body.query || req.query.query || {},
                 Headers: req.body.headers || req.query.headers || {},
             };
             data = {

--- a/server/sts-auth.js
+++ b/server/sts-auth.js
@@ -162,6 +162,7 @@ var getTempKeys = function (callback) {
         if (body && body.data) body = body.data;
         tempKeysCache.credentials = body.credentials;
         tempKeysCache.expiredTime = body.expiredTime;
+        tempKeysCache.policyStr = policyStr;
         callback(err, body);
     });
 };

--- a/server/sts-auth.js
+++ b/server/sts-auth.js
@@ -209,8 +209,7 @@ app.all('/sts-auth', function (req, res, next) {
     });
 });
 app.all('*', function (req, res, next) {
-    res.writeHead(404);
-    res.send('404 Not Found');
+    res.status(404).send('404 Not Found');
 });
 
 // 启动签名服务


### PR DESCRIPTION
1. 修复因没有记录policyStr而导致的expiredTime无效问题。你判断了`tempKeysCache.expiredTime - Date.now() / 1000 > 30` 和 `tempKeysCache.policyStr === policyStr`这两个条件，但empKeysCache.policyStr自始至终都是'',所以过期时间并没有效果，这样即使没过期，依然会再次请求。

2. 修复 [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client 的报错. 如果你需要设置404的状态码，使用`res.status(404)`即可，`res.writeHead(404);res.send('404 Not Found')`会导致`Cannot set headers after they are sent to the client `的报错