### PR TITLE
fix: 修改d.ts GetObjectParams DataType字段名错误

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1137,7 +1137,7 @@ declare namespace COS {
   // getObject
   /** getObject 接口参数 */
   interface GetObjectParams extends ObjectParams {
-    BodyType?: 'text' | 'blob' | 'arraybuffer',
+    DataType?: 'text' | 'blob' | 'arraybuffer',
     /** 请求里的 Url Query 参数，传入该值中的 key/value 将会被 URLEncode */
     Query?: Query,
     /** 请求里的 Url Query 参数。传入该值将直接拼接在 Url 上，不会对其进行 URLEncode */


### PR DESCRIPTION
描述的是BodyType，导致穿错，拿到的类型和预期不一样。 