### PR TITLE
fix: 修复 isNode 环境判断不严谨的问题，兼容 web worker 环境

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cos-js-sdk-v5",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "JavaScript SDK for [腾讯云对象存储](https://cloud.tencent.com/product/cos)",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/cos.js
+++ b/src/cos.js
@@ -78,6 +78,6 @@ COS.util = {
     json2xml: util.json2xml,
 };
 COS.getAuthorization = util.getAuth;
-COS.version = '1.3.9';
+COS.version = '1.3.10';
 
 module.exports = COS;

--- a/src/util.js
+++ b/src/util.js
@@ -710,7 +710,13 @@ var error = function (err, opt) {
 }
 
 var isNode = function () {
-    return typeof window !== 'object' && typeof process === 'object' && typeof require === 'function';
+    // 得兜底 web worker 环境中 webpack 用了 process 插件之类的情况
+    return typeof window !== 'object' && typeof process === 'object' && typeof require === 'function' && !isWebWorker();
+}
+
+var isWebWorker = function () {
+    // 有限判断 worker 环境的 constructor name 其次用 worker 独有的 FileReaderSync 兜底 详细参考 https://developer.mozilla.org/zh-CN/docs/Web/API/Web_Workers_API/Using_web_workers
+    return globalThis.constructor.name === 'DedicatedWorkerGlobalScope' || globalThis.FileReaderSync;
 }
 
 var isCIHost = function(url) {


### PR DESCRIPTION
在 web worker 环境中（比如 vscode worker 插件）使用此 sdk 时，isNode 环境判断不严谨，导致控制台打印了不必要的 warning
<img width="1216" alt="image" src="https://user-images.githubusercontent.com/13809539/178673795-aeea290a-d980-4636-b957-25a6fcd7d079.png">
