### PR TITLE
fix: getAllResponseHeaders 可能返回null

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -37,14 +37,17 @@ var queryStringify = function(obj, sep, eq, name) {
 
 var xhrRes = function (err, xhr, body) {
     var headers = {};
-    xhr.getAllResponseHeaders().trim().split('\n').forEach(function (item) {
-        if (item) {
-            var index = item.indexOf(':');
-            var key = item.substr(0, index).trim().toLowerCase();
-            var val = item.substr(index + 1).trim();
-            headers[key] = val;
-        }
-    });
+    var strHeaders = xhr.getAllResponseHeaders();
+    if (strHeaders && strHeaders.length > 0) {
+        strHeaders.trim().split('\n').forEach(function (item) {
+            if (item) {
+                var index = item.indexOf(':');
+                var key = item.substr(0, index).trim().toLowerCase();
+                var val = item.substr(index + 1).trim();
+                headers[key] = val;
+            }
+        });
+    }
     return {
         error: err,
         statusCode: xhr.status,


### PR DESCRIPTION
根据

The [XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) method getAllResponseHeaders() returns all the response headers, separated by [CRLF](https://developer.mozilla.org/en-US/docs/Glossary/CRLF), as a string, or returns null if no response has been received.ary/CRLF), as a string, or returns null if no response has been received.

该函数是可能返回为null的，不进行判断的话会导致异常。