### PR TITLE
fix: getSourceParams兼容任何域名的场景

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -223,9 +223,7 @@ var parseSelectPayload = function (chunk) {
 var getSourceParams = function (source) {
   var parser = this.options.CopySourceParser;
   if (parser) return parser(source);
-  var m = source.match(
-    /^([^.]+-\d+)\.cos(v6|-cdc|-cdz|-internal)?\.([^.]+)\.((myqcloud\.com)|(tencentcos\.cn))\/(.+)$/
-  );
+  var m = source.match(/^([^.]+-\d+)\.cos(v6|-cdc|-cdz|-internal)?\.([^.]+)\.((([^\/]+)))\/(.+)$/);
   if (!m) return null;
   return { Bucket: m[1], Region: m[3], Key: m[7] };
 };


### PR DESCRIPTION
sdk仅支持了myqcloud.com和tencentcos.cn，本修改将支持的域名扩展到匹配所有域名。